### PR TITLE
Fix composer autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "type": "library",
     "license": "LGPLv3",
     "autoload": {
-        "classmap": ["IP2Location.php"]
+        "psr-4": {
+            "IP2Location\\": ""
+        }
     },
     "authors": [
         {


### PR DESCRIPTION
After updating IP2Location to latest version, I got the below this error `Class 'IP2Location' not found`. This PR will fix this issue.
